### PR TITLE
fix flaky test

### DIFF
--- a/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
+++ b/cluster/src/test/java/org/apache/iotdb/cluster/query/ClusterPlanExecutorTest.java
@@ -83,11 +83,17 @@ public class ClusterPlanExecutorTest extends BaseQueryTest {
   @Test
   public void testGetAllStorageGroupNodes() {
     List<IStorageGroupMNode> allStorageGroupNodes = queryExecutor.getAllStorageGroupNodes();
+    List<IStorageGroupMNode> test = IoTDB.metaManager.getAllStorageGroupNodes();
+    HashSet<String> s1 = new HashSet<String>();
+    HashSet<String> s2 = new HashSet<String>();
     for (int i = 0; i < allStorageGroupNodes.size(); i++) {
-      assertEquals(
-          IoTDB.metaManager.getAllStorageGroupNodes().get(i).getFullPath(),
-          allStorageGroupNodes.get(i).getFullPath());
+      s1.add(allStorageGroupNodes.get(i).getFullPath());
+      s2.add(test.get(i).getFullPath());
+      // assertEquals(
+      //     IoTDB.metaManager.getAllStorageGroupNodes().get(i).getFullPath(),
+      //     allStorageGroupNodes.get(i).getFullPath());
     }
+    assertEquals(s1, s2);
   }
 
   @Test


### PR DESCRIPTION
The test 

`ClusterPlanExecutorTest.testGetAllStorageGroupNodes`


compares the result of function allStroageGroupNodes. However, the function allStroageGroupNodes did not return the element in deterministic order. 

Running 
`mvn -pl cluster edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=ClusterPlanExecutorTest#testGetAllStorageGroupNodes -DnondexRuns=10` will cause the test fail.
I fix the test by changing list data structure to hashset.